### PR TITLE
fix: upgrade Node.js version to 20 in GitHub Actions workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: yarn
 
       - name: Install dependencies


### PR DESCRIPTION
package.json requires Node.js >=20.0 but the workflow was using Node.js 18,
causing yarn install to fail with engine incompatibility error.

