### PR TITLE
Add multilingual support and navbar blur

### DIFF
--- a/blog-en/2024-07-21-first-post.md
+++ b/blog-en/2024-07-21-first-post.md
@@ -1,0 +1,42 @@
+---
+slug: first-post
+title: First Post
+---
+
+## A Person Who Loves Manuals
+
+I love reading manuals. Before I touch almost any consumer product or service, I need to look through its design intent, features, and branding copy. I remember my friends finding it odd that, after buying my first car, I left it untouched and read the manual from page one. I'm the sort of person who reads "Health Benefits of Buckwheat" at a restaurant while waiting for the food.
+
+<!-- truncate -->
+
+That is how I enjoy a product. A good manual puts me in a good mood before I've even started using it. Product documentation, to me, is an important part of the user experience. Having absorbed so many different kinds of documentation over the years, I've naturally developed opinions. Lately I gravitate toward documentation that commits to user empowerment. I'll write about that separately.
+
+## A Developer Who Communicates
+
+This interest carried over into my career as a developer. Over the past ten years, I actively sought out opportunities to explain the products I worked on, in many different forms. Here's a rough list:
+
+- Writing user guides, API reference docs, and release notes for B2B, B2C, and internal products
+- Writing sample code for SDKs and building demo applications
+- Running technical support sessions for partners and individual creators
+- Preparing materials for in-house technical presentations
+- Operating the company tech blog and research archive contribution process
+
+Throughout my time working in teams, I've always believed in the power of clear explanation. For an organization to move without wasted effort, I think it's crucial that everyone understands the purpose of the work and stays aligned. As a team member, I supported leaders who took time to explain. When leading teams myself, I worked with the conviction that the time I spent writing something down saved far more time for everyone who would later read it, multiplied by however many people that was.
+
+For example, I valued writing a [Readme](https://tom.preston-werner.com/2010/08/23/readme-driven-development.html) for internal projects, or producing clean migration guides when APIs changed. I treated sharing a meeting agenda beforehand, distributing meeting notes afterward, and keeping the team's documentation up to date as core responsibilities.
+
+As a developer, I've always found a quiet satisfaction in work that involves explaining something. I consistently got good reviews in the "communication" category, and I thought of this as my particular edge inside a development organization.
+
+## Expanding Beyond Being a Developer
+
+Having someone like me on a development team was probably a useful complement. But as years passed, I started wanting my career to grow in a broader direction. If "communication within a development organization" was my strength, I wanted to build real expertise in it and extend my influence. That's when I realized there was no clear path upward on the developer track that matched where I was trying to go.
+
+Around my seventh year, during a backend developer interview, the interviewer asked: "What would you want to do first if you joined the team?" I answered honestly: "I'd start by assessing whether our API documentation is in good shape and work on improving it. And if there are any request parameters or response fields in the API that serve no real purpose, I'd clean those up." The interviewer tilted their head.
+
+Putting moments like that together with the bigger picture, I came to the conclusion that "communication skills" as a developer didn't, at their core, lead to materially better outcomes for either me or the company. The strength I thought of as my weapon was starting to read more like "I'm a decent person, really." I became convinced that to build genuine expertise and expand my influence using what I was actually good at, I'd need to move beyond being an individual contributor developer into a different role.
+
+## Starting This Blog
+
+The search and trial-and-error involved in that transition is still ongoing, and it isn't easy. In a world changing this fast, it may be something I have to keep working through for as long as I'm working at all. Some days feel unsettled and anxious. Starting this blog is, in part, an attempt to soothe those feelings a little.
+
+I can't be the only person wrestling with the same questions. I hope this blog becomes a place to share thoughts and information about navigating a career. And maybe, just maybe, someone who is looking for exactly what I have to offer will find me here, and something new will open up.

--- a/blog-en/2024-09-14-geultto-life-map.md
+++ b/blog-en/2024-09-14-geultto-life-map.md
@@ -1,0 +1,66 @@
+---
+slug: geultto-life-map
+title: "[Geultto] Life Map - Bohyun Jung"
+unlisted: true
+---
+
+:::info
+
+This is my 'Life Map' submitted for the Geultto 10th cohort application.
+It is a revised and expanded version of my blog's [first post](/en/first-post), written last July.
+
+:::
+
+Foreign Language High School, Art College, Software Developer.
+
+These three words trace the path I've walked. At first glance they look like an unrelated sequence thrown together by chance, but each of my choices had its own reasons at the time. Grateful for the chance to explore such different domains in this wide world, I sometimes wonder what story I'll fill the next chapter with.
+
+Those who've lived a similar life will probably relate: explaining our own life's trajectory is something we're used to, and something we'll likely keep doing for the rest of our lives. Because it's often hard to find a single clear word to define ourselves, we constantly have to brand ourselves. I sometimes think of this as the cost of having followed my instincts and interests. There were certainly easier paths that would have led to a more simply defined identity.
+
+## A Person Who Loves Manuals
+
+Starting with what I love: I really love manuals.
+
+Take a look at a manual. Inside you'll find not just instructions for using a product "correctly" and "well," but storytelling and narrative about the product itself. I also find it fascinating to see how manuals for products exported to multiple language markets use illustrations and symbols to communicate across barriers. The greatest tech products aren't purely great in a technical sense. A manual accompanies you from the very beginning to the very end of your journey with a product.
+
+Before I touch almost any consumer product or service, I need to look through its design intent, features, and branding copy. I remember my friends finding it odd that, after buying my first car, I left it untouched and read the manual from page one. Reading things like "Health Benefits of Buckwheat" at a restaurant while waiting for the food is a habit of mine.
+
+That is how I enjoy a product. A good manual puts me in a good mood before I've even started using it. That's how much I see product documentation as an important part of the user experience.
+
+Does a little of the Foreign Language High School, Art College, Software Developer story come through now?
+
+## A Developer Who Communicates
+
+This interest carried over into my career as a developer. Over the past ten years, I actively sought out opportunities to explain the products I worked on, in many different forms. Here's a rough list:
+
+- Writing user guides, API reference docs, and release notes for B2B, B2C, and internal products
+- Writing sample code for SDKs and building demo applications
+- Running technical support sessions for partners and individual creators
+- Preparing materials for in-house technical presentations
+- Operating the company tech blog and research archive contribution process
+
+Throughout my time working in teams, I've always believed in the power of clear explanation. For an organization to move without wasted effort, I thought it was crucial for everyone to understand the purpose of the work and stay aligned. As a team member, I always supported leaders who took time to explain. When leading teams myself, I operated with the conviction that the time I spent writing something down saved far more time for everyone who would later reference it, multiplied by however many people that was.
+
+For example, I valued writing a [Readme](https://tom.preston-werner.com/2010/08/23/readme-driven-development.html) for internal projects, or producing clean migration guides when APIs changed. I treated sharing a meeting agenda beforehand, distributing meeting notes afterward, and keeping the team's documentation up to date as core responsibilities.
+
+As a developer, working on anything that involved explanation gave me a sense of satisfaction and efficacy. I consistently got good reviews in the "communication" category, and I thought of this as my particular edge for thriving inside a development organization.
+
+## The Need to Expand: Beyond Being a Developer
+
+Having someone like me on a development team was probably not a bad thing. But as years passed, I started craving career expansion. If "communication within a development organization" was my strength, I wanted to build genuine expertise in it and extend my influence. That's when I realized there was no clear next step on the developer track that matched where I wanted to go.
+
+Around my seventh year, during a backend developer interview, the interviewer asked: "What would you want to do first if you joined the team?" I answered honestly: "I'd start by assessing whether our API documentation is in good shape and improving it. And if there are any request parameters or response fields in the API that serve no real purpose, I'd clean those up." The interviewer tilted their head in puzzlement.
+
+Putting moments like that together with the bigger picture, I came to the conclusion that "communication skills" as a developer didn't, at their core, lead to materially better outcomes, whether for the company or for me. The strength I thought of as my weapon was starting to read more like "I'm a decent person, really." I became convinced that to build genuine expertise and expand my influence using what I was actually good at, I'd need to move beyond being an individual contributor developer into a different role.
+
+## Ten Years In, the Journey Continues
+
+The search and trial-and-error involved in that transition is ongoing, and it isn't simple. In a world changing this fast, it may be something I need to keep working through for as long as I'm working at all. I'm gradually testing different options built on my experience and skills, and I think I'm beginning to get a feel for things. Broadly, I want to try something that lets me design developer experiences through technical content.
+
+Whatever direction I choose, I'll move forward without regrets, as I always have. And someday I'll no doubt find myself wondering about the next journey.
+
+## Why I'm Applying to Geultto's 10th Cohort
+
+My reason is simple. As I mentioned at the top, I'm someone who needs to explain herself. I've written about products before, but I've never had the habit of writing and publishing about myself. It's been almost two months since I posted my [first post](/en/first-post), and it took this Geultto application to finally get me to write a revised version.
+
+Also, I can't be the only one grappling with the same or similar questions. Through Geultto, I hope to share thoughts with others and find companions to move forward with.

--- a/blog-en/2024-10-13-what-to-write.md
+++ b/blog-en/2024-10-13-what-to-write.md
@@ -1,0 +1,37 @@
+---
+slug: what-to-write
+title: What Should I Write? Geultto, Help Me Out
+unlisted: true
+---
+
+## Borrowing Geultto's Momentum
+
+Nearly three months have passed since I boldly launched this blog. I thought the second post would come more easily than the first, but it turned out to be the opposite. Not because I have nothing to write about. In the second half of this year, I've been thinking a great deal about the direction of my career, encountering new ideas, meeting all kinds of people, quietly accumulating material for future posts. What I lacked was the resolve to commit to a topic and a deadline, and the perfectionist in me made it hard to start at all, since I wanted to write well if I was going to write.
+
+<!-- truncate -->
+
+That's when, hoping to break through the standstill, I joined a developer writing community called Geultto last September. I first heard about Geultto a few years ago. I remember watching a colleague participate in it and thinking I'd like to try it someday. When I launched this blog and made myself a promise to write, Geultto seemed like a good opportunity to follow through, since the community is built around writing one post every two weeks. This tenth cohort, active through March 2025, is said to be Geultto's final one. With around 640 developers participating, the scale is remarkable.
+
+This post is my first as a Geultto member. I'm using it to make a commitment and a promise about what I'll write here going forward.
+
+## What I Plan to Write
+
+As I mentioned in my [first post](/en/first-post), the shift toward a role where communication is my primary skill will be the through-line of what I write. Exploring that direction has been an ongoing effort over several years, but the second half of 2023 was unlike any other period. I absorbed more information and ideas, and thought harder about the direction of my career, than ever before. As a result, I can now start to see a path forward. I want to talk about the efforts I made throughout that process, the new things I discovered, and what I came to understand.
+
+* What kinds of roles place a high value on technical communication?
+* Of those, which have I experienced directly or indirectly?
+* And the direction I've set for myself: "designing developer experiences through technical content"
+
+I also want to organize and share various thoughts on communication within and around the tech industry:
+
+* The mindset behind building a product for people
+* The importance of written documentation within organizations and projects
+* The Docs as Code movement
+
+Beyond those, I'd like to introduce interesting products related to my areas of interest, and when I come across a good article or podcast, translate it, share it here, and add my own thoughts.
+
+## In the End, It's Me Who Has to Write
+
+No matter how much of my deposit I stand to lose by missing posts, or how many fellow members are writing and cheering each other on, it's still up to me to actually write. Especially given the weight of the topics I've chosen, two weeks feels shorter than I expected. So I'll need to get into the habit of organizing my thoughts as I go, doing the necessary research, and preparing ahead of time.
+
+Next post topic: **"The mindset behind building products for customers"**

--- a/blog-en/2024-10-27-technology-as-a-gift.md
+++ b/blog-en/2024-10-27-technology-as-a-gift.md
@@ -1,0 +1,46 @@
+---
+slug: technology-as-a-gift
+title: "Technology as a Gift"
+---
+
+What does it mean to see technology as a gift? The experimental educational program '[SFPC Summer 2019 in Yamaguchi](https://www.ycam.jp/en/events/2019/sfpc/),' held in Yamaguchi, Japan in 2019, began from this very question. Organized by the [School For Poetic Computation (SFPC)](https://www.instagram.com/sfpc_nyc/), an experimental school based in New York, the program explored the intersection of art, code, hardware, and theory under the theme "Technology as a Gift." Having followed SFPC's work with great interest, I participated in this ten-day program just before the Chuseok holiday in 2019, and it was there that I was able to completely shift my perspective on the products and technology I build as a software developer.
+
+<!-- truncate -->
+
+:::note
+
+A reflection on participating in [SFPC Summer 2019 in Yamaguchi](https://medium.com/sfpc/sfpc-in-yamaguchi-thanksgiving-for-the-program-1336f8c5e63f)
+
+:::
+
+## The Meaning of a Gift
+
+When we try to understand something from a new angle, we often turn to metaphor. Seeing technology as a gift starts with understanding the essence of a gift itself.
+
+![](/img/blog/2024-10-27-technology-as-a-gift/1.png)
+
+The "This is a gift" checkbox you encounter when ordering on Amazon doesn't simply signal a functional difference: no receipt, add a message card. It represents something deeper: thoughtfulness. When we choose a gift, we think beyond the transaction itself. We think more carefully about our relationship with the recipient, about what they actually need. We move past the bestsellers and algorithm recommendations, and instead make deliberate choices from options selected with the recipient's tastes and situation in mind.
+
+## Seeing a Friend's Name as Nothing More Than a String
+
+I came to understand just how important this shift in perspective really is through a small incident during the program.
+
+On day three, a Japanese participant named Kiwako proposed a "coffee chat" idea for students, SFPC instructors, and YCAM staff. The idea: gather people who wanted to participate, randomly pair them one-on-one, and give everyone a chance to get to know each other. Jim, a Thai participant, and I volunteered to build the random matching system. Jim took the front end; I handled the back end, writing the matching logic and the code to store matching records. Implementation took a single night. On the first day the system was available, everyone who signed up found their partner on the screen and spent time together.
+
+![](/img/blog/2024-10-27-technology-as-a-gift/2.gif)
+
+The incident happened on the second day of running matches. That day, the number of sign-ups was odd. Our system handled the last unpaired person like `("John Doe", "")`. A friend named Takashi appeared at the very bottom of the screen without a partner, and he looked somewhat confused. Kiwako quickly added him to the last group to make it a three-person coffee chat, but I felt a deep sense of regret. Until that moment, I had been looking at the list of names as nothing more than an array of text data. I hadn't thought at all about the experiences and feelings of the people behind each name.
+
+If only I had seen this system as a gift for people who were looking forward to the moment of connecting with someone new...
+
+## Giving Gifts to Developers Too
+
+Since that small incident in 2019, I've carried with me a mindset of treating the products I work on as gifts. In truth, seeing a product as a gift aligns with the User Experience (UX)-centered approach to product design that has become widely adopted across the industry. But the context in which we usually discuss UX tends to be limited to end users of B2C services.
+
+As someone who began their career as a backend API developer, what I found myself thinking more deeply about was Developer Experience. Whenever I encountered undocumented APIs hiding behind "it's just for internal use," documentation that the author clearly hadn't read themselves, or endpoint designs built on no discernible principles, I kept asking the same question: why, after dividing software into modules, adopting microservice architectures, and reshaping organizations to match, are we so negligent when it comes to organizing the protocols these systems use to communicate with each other? It's even more disheartening when I sense an attitude of "build it and they'll figure it out" in the products of companies that provide APIs or SDKs to business customers.
+
+But shouldn't developers deserve good gifts too? We ought to place far greater value on the act of giving gifts to developers. And those gifts will ultimately have to be something we developers give to one another.
+
+All this time, I've been searching for a role where I can put these ideas into practice. Starting in November, I'm beginning a new challenge as a Developer Advocate. When technology becomes a gift, we move beyond mere feature implementation and think more deeply about the experience of both users and developers alike. That, in turn, leads to a better development culture and better products. I'm now ready to seriously explore and practice what the perspective of "technology as a gift" can bring about.
+
+Next post topic: **Someone who delivers technology as a gift: starting as a Developer Advocate**

--- a/blog-en/2024-11-10-from-evangelist-to-advocate.md
+++ b/blog-en/2024-11-10-from-evangelist-to-advocate.md
@@ -1,0 +1,38 @@
+---
+slug: from-evangelist-to-advocate
+title: "From Evangelist to Advocate"
+---
+
+## An Evangelist from Childhood Memory
+
+My name carries a Buddhist meaning, and my family practices Buddhism. Yet for some reason, I attended a kindergarten run by a Christian organization. Most of those memories are too distant to recall clearly now, but one person stands out. Someone who opened the door of the school van and made sure we arrived safely each morning and afternoon, who asked how we were feeling at the start and end of every day, who watched over the children and gave advice on how to get along better with friends. We called him the *jeondobsa-nim*, the evangelist, and that is what the word has always meant to me.
+
+<!-- truncate -->
+
+## Tech Evangelist
+
+Many years later, having grown up, I found myself doing the work of an evangelist too. Only, instead of the Korean word, the role goes by the English name "evangelist," specifically a tech evangelist, because it involves building relationships with developers through a specific technology and cultivating a technical ecosystem around it.
+
+The work a tech evangelist does has much in common with what my childhood evangelist did. It means guiding developers on their first journey into a technology product, watching out for any difficulties they encounter along the way, and spreading the word about how best to use it.
+
+My move toward this direction is closely tied to the interests and tendencies I've described in earlier posts on this blog. Throughout my time as a developer, I always kept an eye on the areas within the tech industry where communication and care were lacking. If there's one thing that sets my heart on fire while I work, something [ikigai](https://en.wikipedia.org/wiki/Ikigai)-worthy, it's developer experience.
+
+Just as B2C products don't sell themselves to consumers, technical products used by developers don't sell themselves either. The process requires constant communication and attentiveness toward developers inside and outside the organization, along with the documentation and training they actually need. That kind of effort will likely take the form of dedicated people assigned to do exactly this work. That is what a tech evangelist does.
+
+## My Experience at NAVER Z
+
+The first place I experienced tech evangelist work was NAVER Z, the company behind the metaverse service ZEPETO, where I worked until recently. It was a broad role: building an ecosystem of developers using a tool called the ZEPETO World SDK, delivering technical content to developers, and handling everything from training to technical support. In Korea, where B2B SaaS and API/SDK-based technical product businesses haven't yet fully taken root, it was a rare opportunity. The particular draw was that ZEPETO had already built up a global user base, meaning I could work with developers and partners from countries all over the world who were building ZEPETO Worlds.
+
+Once, I provided technical support via video call to a company in Israel. They were under a tight launch timeline and needed a feature that was absolutely essential to them, so they asked whether I could relay their request to the SDK development team. I listened to their requirements, filed an issue with the development team, and the new feature was prioritized and developed relatively quickly. I then wrote up how to use it and personally walked the partner through it in a follow-up session.
+
+The whole process was genuinely fun and rewarding for me. And beyond that, I discovered that writing documentation for developers and creating sample code is a domain with its own kind of satisfaction and career potential, distinct from writing code as a developer in the traditional sense. Due to the direction the company's operations took, I wasn't able to do the evangelist work as long as I had hoped. But my appetite for doing this more deeply and professionally, helping developers and partners succeed through communication with technology, only grew stronger.
+
+## A New Challenge: MongoDB Developer Advocate
+
+Then, about three months ago, I was contacted by a MongoDB recruiter on LinkedIn. The message asked whether I'd be interested in working as a Senior Developer Advocate at MongoDB. I took an exploratory call, thought it was a good opportunity, and applied. I went through a total of ten interviews over about a month and a half, and after accepting the offer, I start tomorrow.
+
+Developer Advocate and tech evangelist are similar roles at a high level, but there's a nuance in the distinction. In particular, moving away from the religious connotations of "evangelist," "advocate" implies siding with the developer, acting as a bridge between developers and the company providing the product.
+
+As a Senior Developer Advocate, I'll be working alongside talented teammates I'd already met multiple times during the interview process, carrying out developer enablement and community-building activities for MongoDB across APAC, including Korea. This will primarily involve writing technical educational content aimed at developers, running workshops, and leading hands-on sessions. Working with the field marketing team to build effective strategies for engaging with customers and developers is also part of the role.
+
+I'm going into this new opportunity with genuine excitement and anticipation. I hope to put my past experience together with what I'll be learning, and contribute to the team quickly. I'm already looking forward to sharing what I discover through this blog.

--- a/blog-en/2024-12-23-six-weeks-at-mongodb.md
+++ b/blog-en/2024-12-23-six-weeks-at-mongodb.md
@@ -1,0 +1,69 @@
+---
+slug: six-weeks-at-mongodb
+title: "Looking Back at My First Six Weeks at MongoDB"
+image: "/img/blog/2024-12-23-six-weeks-at-mongodb/4.jpg"
+---
+
+Six weeks have passed since I joined MongoDB on November 11th. They've been packed with all kinds of activities, from the company's well-structured onboarding program to early chances to shadow real work. In this post, I'd like to briefly look back on the experience so far.
+
+<!-- truncate -->
+
+## Onboarding Program
+
+MongoDB's onboarding was, hands down, the best new-employee orientation I've experienced across five companies.
+
+The Leadership Commitment series, held over several weeks, was a core training program covering MongoDB's product design philosophy, core values, leadership principles, the customer journey, and inclusion. It was remarkably dense and well-delivered. What stood out in particular was that much of the content was presented directly by company executives, including the CEO.
+
+The new-hire technical training was a twenty-plus-hour program covering MongoDB's core features, document data modeling, [Atlas](https://www.mongodb.com/atlas) (MongoDB's cloud developer data platform), indexes, distributed architecture, and administrative capabilities. After watching chapter videos, we took quizzes to check our understanding. Being able to run examples directly on a provisioned MongoDB cluster was a huge help for hands-on learning.
+
+Beyond the company-wide onboarding, there were also organization-specific programs. I worked through the new-employee training materials for both Marketing and Developer Relations, which helped me get familiar with more day-to-day operational information.
+
+## About the Role
+
+In my [previous post](/en/from-evangelist-to-advocate), written before I joined, I briefly described what the role would involve based on the job description and what I'd learned through interviews. My first six weeks were, more than anything, a time for developing a much deeper and clearer understanding of the work ahead.
+
+Just as MongoDB's tagline is [Love Your Developers](https://www.mongodb.com/company/love-your-developers), developers are at the core of what makes MongoDB successful. MongoDB's Developer Relations team improves and accelerates developer productivity through a variety of Advocacy & Enablement programs:
+
+- Creating content that raises market awareness and drives adoption
+- Educating developers through workshops and live hands-on sessions
+- Engaging strategic customers and providing data modeling consultation
+
+## First Business Trip
+
+In my second week, I went on my first business trip: MongoDB Days held in Manila and Ho Chi Minh City. Since the events included developer training and data modeling consultation, activities that would become part of my work after onboarding, it was a chance to experience those things firsthand ahead of time.
+
+| ![](/img/blog/2024-12-23-six-weeks-at-mongodb/2.jpg) | ![](/img/blog/2024-12-23-six-weeks-at-mongodb/3.jpg) |
+| :--------------------------------------------------: | :--------------------------------------------------: |
+|         *With DevRel APAC teammate Sourabh*          |          *With DevRel APAC teammate Wenjie*          |
+
+What I was most grateful for was getting to meet my fellow Developer Advocates on the DevRel APAC team in person. Events tend to thin out toward the end of the year, and joining in November meant the timing worked out perfectly. Sourabh and Wenjie are seniors who started as Developer Advocates at least a year ahead of me. Watching them deliver various sessions with such charisma and professionalism made me want to reach their level as quickly as I could.
+
+|  ![](/img/blog/2024-12-23-six-weeks-at-mongodb/1.jpg)   |
+| :-----------------------------------------------------: |
+| *With ASEAN regional staff after the MongoDB Days Ho Chi Minh City event* |
+
+I also got to meet Solutions Architects, Field Marketers, and Customer Success Managers from across the ASEAN region. Seeing how Developer Advocates collaborate with them in planning and running an event was enormously helpful. In between sessions and at the group dinner afterward, I had wide-ranging conversations with staff from all over the region.
+
+A second business trip is planned for Taipei in January, where I'll run my first developer session at MongoDB. I'm nervous, but excited.
+
+## Introduction to the Korea Office
+
+| ![](/img/blog/2024-12-23-six-weeks-at-mongodb/4.jpg) |
+| :--------------------------------------------------: |
+|          *The Jamsil view from the Korea office*          |
+
+It goes without saying that bringing on someone based in Korea is about building programs for key customers and developers in Korea. So over these six weeks, I've had various opportunities to introduce myself to members of MongoDB's Korea office. Drawing on the model of how Developer Advocates work alongside local teams across APAC, we'll gradually build a similar collaborative structure in Korea.
+
+Last week I attended the Korea office's year-end party. The culture of an international company, I found, has its own distinct character compared to the Korean IT companies I've worked at before.
+
+## Communication, Communication, Communication
+
+What struck me most was the open, multidirectional communication flowing throughout the entire company.
+
+My manager Nick regularly set up 1:1 sessions to check in on the onboarding process and sincerely ask whether there was anything he could help with. Whether it was checking on my well-being given Korea's political situation at the time, or reminding me to put family first whenever something came up, I genuinely felt looked after, both as a person and psychologically. The separation between managers and ICs was something I'd only heard about before; joining MongoDB was my first time experiencing it. I could feel the ease and comfort that having a dedicated manager gives to individual contributors.
+
+I also had casual introductory sessions with six or seven people I'll be working closely with from various teams, hearing about their roles and responsibilities. I used those conversations as opportunities to talk about my own background and interests. Being in an environment where expressing interest in something, or asking questions without hesitation, felt natural and encouraged. It was refreshing and fun.
+
+Finally, I attended two monthly All-Hands meetings with direct participation from C-level leaders. Employees could submit questions in advance or ask in real time via live chat; the topics ranged widely and went deep, and the executives' answers were candid and unguarded. I was genuinely impressed.
+
+That wraps up a record of my first six weeks at MongoDB. I'm looking forward to the days ahead. January and February will be when I start taking on real work. Let's do this well.

--- a/blog/2024-10-13-what-to-write.md
+++ b/blog/2024-10-13-what-to-write.md
@@ -1,6 +1,7 @@
 ---
 slug: what-to-write
 title: 어떤 글을 쓸까 - 글또야 도와줘
+unlisted: true
 ---
 
 ## 글또의 힘을 빌려

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -10,17 +10,36 @@ const config: Config = {
   baseUrl: '/',
 
   onBrokenLinks: 'throw',
-
-  markdown: {
-    hooks: {
-      onBrokenMarkdownLinks: 'warn',
-    },
-  },
+  onBrokenMarkdownLinks: 'warn',
 
   i18n: {
     defaultLocale: 'ko',
     locales: ['ko'],
   },
+
+  // Detect browser language on first visit and redirect non-Korean speakers to /en.
+  // Saves preference to localStorage ('bhj-lang': 'ko' | 'en') so manual choices persist.
+  headTags: [
+    {
+      tagName: 'script',
+      attributes: {},
+      innerHTML: `(function(){try{var k='bhj-lang',s=localStorage.getItem(k),e=location.pathname.startsWith('/en');if(s==='en'&&!e){location.replace(location.pathname==='/'?'/en':'/en'+location.pathname);return;}if(s)return;var l=(navigator.language||(navigator.languages&&navigator.languages[0])||'ko').toLowerCase();localStorage.setItem(k,l.startsWith('ko')?'ko':'en');if(!l.startsWith('ko')&&!e)location.replace('/en');}catch(ex){}})();`,
+    },
+  ],
+
+  plugins: [
+    [
+      '@docusaurus/plugin-content-blog',
+      {
+        id: 'blog-en',
+        path: './blog-en',
+        routeBasePath: '/en',
+        blogSidebarCount: 0,
+        showReadingTime: false,
+        blogListComponent: '@theme/BlogListPage',
+      },
+    ],
+  ],
 
   presets: [
     [
@@ -48,6 +67,10 @@ const config: Config = {
     navbar: {
       title: 'bohyunjung.com',
       items: [
+        {
+          type: 'custom-lang-toggle',
+          position: 'right',
+        },
         { to: '/about', label: 'About', position: 'right' },
         {
           to: 'https://github.com/bohyunjung',

--- a/src/components/LanguageToggle/index.tsx
+++ b/src/components/LanguageToggle/index.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { useLocation } from '@docusaurus/router';
+import styles from './styles.module.css';
+
+const LANG_KEY = 'bhj-lang';
+
+async function switchTo(lang: 'ko' | 'en', pathname: string) {
+  try { localStorage.setItem(LANG_KEY, lang); } catch {}
+
+  const fallback = lang === 'en' ? '/en' : '/';
+  const target =
+    lang === 'en'
+      ? pathname === '/' ? '/en' : `/en${pathname}`
+      : pathname.replace(/^\/en/, '') || '/';
+
+  // If the target is not the fallback, verify the page exists first.
+  // A missing post (404) falls back to the language root instead.
+  if (target !== fallback) {
+    try {
+      const res = await fetch(target, { method: 'HEAD' });
+      window.location.href = res.ok ? target : fallback;
+      return;
+    } catch {
+      // Network error — best-effort fallback
+    }
+  }
+  window.location.href = fallback;
+}
+
+export default function LanguageToggle() {
+  const { pathname } = useLocation();
+  const isEnglish = pathname.startsWith('/en');
+
+  return (
+    <div className={styles.toggle}>
+      <button
+        className={`${styles.btn} ${!isEnglish ? styles.active : ''}`}
+        onClick={() => switchTo('ko', pathname)}
+      >
+        한국어
+      </button>
+      <span className={styles.sep}>/</span>
+      <button
+        className={`${styles.btn} ${isEnglish ? styles.active : ''}`}
+        onClick={() => switchTo('en', pathname)}
+      >
+        English
+      </button>
+    </div>
+  );
+}

--- a/src/components/LanguageToggle/styles.module.css
+++ b/src/components/LanguageToggle/styles.module.css
@@ -1,0 +1,34 @@
+.toggle {
+  display: flex;
+  align-items: center;
+}
+
+.btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--ifm-navbar-link-color);
+  font-family: inherit;
+  font-size: 16px !important;
+  opacity: 0.4;
+  padding: var(--ifm-navbar-item-padding-vertical) 4px;
+  transition: opacity 0.15s ease;
+  line-height: inherit;
+}
+
+.btn:hover {
+  opacity: 0.75;
+}
+
+.active {
+  opacity: 1;
+  color: var(--ifm-color-primary);
+}
+
+.sep {
+  opacity: 0.2;
+  user-select: none;
+  padding: 0 1px;
+  font-size: 16px !important;
+  color: var(--ifm-navbar-link-color);
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -53,6 +53,25 @@ article h1 {
   font-weight: normal;
 }
 
+.navbar {
+  background-color: transparent !important;
+}
+
+.navbar::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  background-color: rgba(250, 250, 250, 0.85);
+  z-index: -1;
+  pointer-events: none;
+}
+
+[data-theme='dark'] .navbar::before {
+  background-color: rgba(27, 27, 29, 0.85);
+}
+
 .pagination-nav {
   display: none;
 }
@@ -63,4 +82,9 @@ article h1 {
 
 .blog-list-page-wrapper article .markdown > h2:first-child {
   margin-top: 0;
+}
+
+/* Prevent language toggle links from inheriting the global font-size override */
+.navbar .navbar__item a[class*="link"] {
+  font-size: 16px !important;
 }

--- a/src/pages/en/about.md
+++ b/src/pages/en/about.md
@@ -1,0 +1,59 @@
+---
+slug: /en/about
+---
+
+# About
+
+Hi, I'm Bohyun Jung, a developer who creates and communicates. I find myself somewhere between the technical and the literary.
+I'm interested in designing developer experiences through technical content.
+
+---
+
+# Technical Content
+
+## **NAVER Z**
+  - ZEPETO World SDK · 2023 - 2024
+    - Built the [API Reference](https://developer.zepeto.me/)
+    - Wrote the [Developer Guide](https://docs.zepeto.me/studio/reference)
+## **Kurly**
+  - Managed the [Tech Blog](https://helloworld.kurly.com/) · 2022 - 2023
+## **Kakao Enterprise**
+  - Built AI Research [Paper Archive](https://kakaoenterprise.github.io/) · 2021
+  - Ran an AI technology experience website · 2021
+  - Built AI application demos · 2021
+    - [Parrotverse](https://youtube.com/shorts/Tpg3SamzY0c?si=eCf-ZxfKEbsD8cxj)
+    - [Aspartame](https://youtube.com/shorts/7VKKMEMLSpc?feature=share)
+    - [VSCode Voice-Coding Plugin](https://www.youtube.com/watch?v=OnxAKXqipsQ) · AGI KR [post](https://bit.ly/3e5DzG3)
+
+---
+
+# Community & Workshops
+
+- Eum Creative Coding [Workshop](https://kdac.or.kr/board/read?boardManagementNo=1&boardNo=2800&level=2&menuNo=2) Instructor · 2021
+- SeMA \<World of Magical Numbers\> [Workshop](https://www.youtube.com/watch?v=tzNgy9kA2Mg) Instructor · 2020
+- SFPC Summer 2019 in Yamaguchi [Workshop](https://www.ycam.jp/en/events/2019/sfpc/) Participant · 2019
+- Peer-to-Peer Folder Poetry · 2019
+  - Hosted [Workshop](https://github.com/ulpc/Peer-to-Peer-Folder-Poetry)
+  - Published [Zine](https://github.com/ulpc/Peer-to-Peer-Folder-Poetry/blob/master/sessions/ulpc/2019-11/zine.pdf)
+- [Trevarri](https://trevari.co.kr/) \<Humans and Technology\> Book Club Partner · 2016 - 2022
+
+---
+
+# Writing & Talks
+
+- Contributor to [\<I'm Doing It for Myself\>](https://product.kyobobook.co.kr/detail/S000201863585) by Ko Jae-hyung · 2023
+- [People Building the Dev Culture at Kurly Commerce Platform](https://helloworld.kurly.com/blog/commerce-platform-facilitators-2022/) · 2023
+- [Expanding Artistic Expression for Different Learners](https://ieum.or.kr/user/webzine/view.do?idx=84) · 2021
+- [Computation — Invention, Not Innovation](http://factory483.org/program/14324) · 2020
+- [SFPC in Yamaguchi — Thanksgiving for the Program](https://medium.com/sfpc/sfpc-in-yamaguchi-thanksgiving-for-the-program-1336f8c5e63f) · 2019
+- [Hangeul Pattern Tool — Planning and Making](https://www.youtube.com/watch?v=U1F5JXPxlcU) · 2017
+
+---
+
+# Interactive Web
+
+- [Code Poetry — In Memory of Cassandre](https://bohyunjung.com/code-poetry-after-cassandre/) · 2021
+- [Inversion Speech Translator](https://www.youtube.com/watch?v=yKpdknz84zQ) inspired by \<Tenet\> (2020) · 2020
+- Naver Special Logos
+  - [Hangeul Pattern Maker](https://logoproject.naver.com/hanguel) · 2017
+  - [Christmas Wreath Maker](https://logoproject.naver.com/christmas) · 2017

--- a/src/theme/BlogPostItem/Footer/index.tsx
+++ b/src/theme/BlogPostItem/Footer/index.tsx
@@ -1,6 +1,6 @@
 import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
-import {useBlogPost} from '@docusaurus/plugin-content-blog/client';
+import {useBlogPost} from '@docusaurus/theme-common/internal';
 import {ThemeClassNames} from '@docusaurus/theme-common';
 import EditMetaRow from '@theme/EditMetaRow';
 import TagsListInline from '@theme/TagsListInline';

--- a/src/theme/BlogPostItem/Header/Info/index.tsx
+++ b/src/theme/BlogPostItem/Header/Info/index.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import clsx from 'clsx';
+import {translate} from '@docusaurus/Translate';
+import {usePluralForm} from '@docusaurus/theme-common';
+import {useBlogPost} from '@docusaurus/theme-common/internal';
+import {useLocation} from '@docusaurus/router';
+import type {Props} from '@theme/BlogPostItem/Header/Info';
+
+import styles from './styles.module.css';
+
+// Very simple pluralization: probably good enough for now
+function useReadingTimePlural() {
+  const {selectMessage} = usePluralForm();
+  return (readingTimeFloat: number) => {
+    const readingTime = Math.ceil(readingTimeFloat);
+    return selectMessage(
+      readingTime,
+      translate(
+        {
+          id: 'theme.blog.post.readingTime.plurals',
+          description:
+            'Pluralized label for "{readingTime} min read". Use as much plural forms (separated by "|") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)',
+          message: 'One min read|{readingTime} min read',
+        },
+        {readingTime},
+      ),
+    );
+  };
+}
+
+function ReadingTime({readingTime}: {readingTime: number}) {
+  const readingTimePlural = useReadingTimePlural();
+  return <>{readingTimePlural(readingTime)}</>;
+}
+
+function DateTime({
+  date,
+  formattedDate,
+}: {
+  date: string;
+  formattedDate: string;
+}) {
+  return <time dateTime={date}>{formattedDate}</time>;
+}
+
+function Spacer() {
+  return <>{' · '}</>;
+}
+
+export default function BlogPostItemHeaderInfo({
+  className,
+}: Props): JSX.Element {
+  const {metadata} = useBlogPost();
+  const {date, readingTime} = metadata;
+
+  const {pathname} = useLocation();
+  const locale = pathname.startsWith('/en') ? 'en-US' : 'ko-KR';
+  const dateTimeFormat = new Intl.DateTimeFormat(locale, {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC',
+  });
+
+  const formatDate = (blogDate: string) =>
+    dateTimeFormat.format(new Date(blogDate));
+
+  return (
+    <div className={clsx(styles.container, 'margin-vert--md', className)}>
+      <DateTime date={date} formattedDate={formatDate(date)} />
+      {typeof readingTime !== 'undefined' && (
+        <>
+          <Spacer />
+          <ReadingTime readingTime={readingTime} />
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/theme/BlogPostItem/Header/Info/styles.module.css
+++ b/src/theme/BlogPostItem/Header/Info/styles.module.css
@@ -1,0 +1,3 @@
+.container {
+  font-size: 0.9rem;
+}

--- a/src/theme/NavbarItem/ComponentTypes.tsx
+++ b/src/theme/NavbarItem/ComponentTypes.tsx
@@ -1,0 +1,7 @@
+import ComponentTypes from '@theme-original/NavbarItem/ComponentTypes';
+import LanguageToggle from '@site/src/components/LanguageToggle';
+
+export default {
+  ...ComponentTypes,
+  'custom-lang-toggle': LanguageToggle,
+};


### PR DESCRIPTION
## Summary
- Add Korean/English language toggle with auto-detection via `headTags` script and custom `LanguageToggle` navbar component
- Add English translations for all posts and about page
- Add backdrop blur to the top navbar using `::before` pseudo-element (avoids mobile sidebar breakage)

## Test plan
- [x] Language toggle works and persists across pages
- [x] All English translations render correctly
- [x] Navbar blur visible on scroll (desktop and mobile)
- [x] Mobile sidebar opens and closes without visual issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)