### PR TITLE
Fix Vercel build error by using npm install instead of npm ci

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "framework": "docusaurus",
   "buildCommand": "npm run build",
   "outputDirectory": "build",
-  "installCommand": "npm ci",
+  "installCommand": "npm install",
   "headers": [
     {
       "source": "/assets/(.*)",


### PR DESCRIPTION
Lock file generated in Linux x64 CI environment omits platform-specific
optional packages (rspack, swc, lightningcss bindings for darwin/win32/arm64),
causing npm ci to fail. Using npm install lets Vercel resolve the correct
packages for its own environment.

https://claude.ai/code/session_01J1NxU69279KJStJuVtqrs3